### PR TITLE
feat: gate amdgcn GPU-sort kernel behind default-on 'gpu-sort' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,17 @@ paste = "1.0.15"
 bindgen = "0.71.1"
 
 [features]
-default = ["macros", "miopen"]
+default = ["macros", "miopen", "gpu-sort"]
 rocm_smi = ["dep:rocm_smi_lib"]
 miopen = []
 rocprofiler = []
 rocsolver = []
 macros=["dep:rocm_kernel_macros"]
+# Embeds the amdgcn GPU bitonic-sort kernel (built via the rocm_kernel_macros
+# proc-macro). Default-on; turn off for hosts where the kernel's nested
+# nightly+build-std cargo build is unavailable (e.g. Windows/MSVC) — GPU sort
+# then becomes a runtime no-op, which inference workloads never hit.
+gpu-sort = ["macros"]
 
 [workspace]
 members = [

--- a/src/hip/memory_ext/sorting.rs
+++ b/src/hip/memory_ext/sorting.rs
@@ -119,6 +119,9 @@ pub(crate) const SORTING_KERNEL: &[u8] = include_bytes!(amdgpu_kernel_finalize!(
 pub(crate) const SORTING_KERNEL: &[u8] = &[];
 
 pub(crate) fn sort<T>(mem: &mut DeviceMemory<T>, stream: &Stream, ascending: bool) -> Result<()> {
+    if !cfg!(feature = "gpu-sort") {
+        return Ok(());
+    }
     let module = Module::load_data(SORTING_KERNEL)?;
 
     let sort_odd =

--- a/src/hip/memory_ext/sorting.rs
+++ b/src/hip/memory_ext/sorting.rs
@@ -102,11 +102,21 @@ macro_rules! impl_gpu_sort_allowed {
 
 impl_gpu_sort_allowed!(i8, i16, i32, i64, u8, u16, u32, u64, f32, f64);
 
+// The embedded amdgcn sort kernel is built at compile time by the external
+// `amdgpu_kernel_finalize!` proc-macro, whose nested `cargo build` inherits the
+// parent rustc env and falls off the nightly+build-std toolchain on non-Linux
+// hosts (Windows/MSVC: "can't find crate for `core`"). GPU sort is never used by
+// LLM inference, so gate the kernel behind the (default-on) `gpu-sort` feature;
+// with it off, `sort()` is a runtime no-op (empty kernel) but the crate builds
+// everywhere. No call sites change.
+#[cfg(feature = "gpu-sort")]
 pub(crate) const SORTING_KERNEL: &[u8] = include_bytes!(amdgpu_kernel_finalize!(
     path = __build_in_kernels_sorting,
     dir = __build_in_kernels_sorting,
     binary_name = sorting
 ));
+#[cfg(not(feature = "gpu-sort"))]
+pub(crate) const SORTING_KERNEL: &[u8] = &[];
 
 pub(crate) fn sort<T>(mem: &mut DeviceMemory<T>, stream: &Stream, ascending: bool) -> Result<()> {
     let module = Module::load_data(SORTING_KERNEL)?;


### PR DESCRIPTION
The embedded amdgcn bitonic-sort kernel is built at compile time by the `amdgpu_kernel_finalize!` proc-macro, which spawns a nested `nightly + build-std` cargo build. That nested build inherits the parent rustc environment and falls off the nightly toolchain on Windows/MSVC, failing with `E0463: can't find crate for core`.

GPU sort isn't exercised by typical consumers (e.g. LLM inference), so this gates the kernel behind a new **default-on** `gpu-sort` feature. With the feature on (the default) behavior is unchanged; with it off, `SORTING_KERNEL` is an empty slice and `sort()` becomes a runtime no-op, letting the crate build on every host (including MSVC) without the nested nightly build. No call sites change.

Built + run on gfx1151 / ROCm 7.13: default features (gpu-sort on) builds and the kernel embeds unchanged; `--no-default-features` builds without the nested nightly build and `sort()` is a no-op.