### PR TITLE
fix: wrap rocblas wrapper bodies in unsafe blocks for edition 2024

### DIFF
--- a/src/rocblas/level1.rs
+++ b/src/rocblas/level1.rs
@@ -77,7 +77,9 @@ pub unsafe fn scal_strided_batched<T>(
 where
     T: ScalStridedBatchedType,
 {
-    T::rocblas_scal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
+    unsafe {
+        T::rocblas_scal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
+    }
 }
 
 //==============================================================================
@@ -133,7 +135,9 @@ pub unsafe fn copy_batched<T>(
 where
     T: CopyBatchedType,
 {
-    T::rocblas_copy_batched(handle, n, x, incx, y, incy, batch_count)
+    unsafe {
+        T::rocblas_copy_batched(handle, n, x, incx, y, incy, batch_count)
+    }
 }
 
 /// Copy vectors in a strided batch

--- a/src/rocblas/level2.rs
+++ b/src/rocblas/level2.rs
@@ -1914,7 +1914,9 @@ pub unsafe fn spr<T>(
 where
     T: SprType,
 {
-    T::rocblas_spr(handle, uplo, n, alpha, x, incx, AP)
+    unsafe {
+        T::rocblas_spr(handle, uplo, n, alpha, x, incx, AP)
+    }
 }
 
 // Similar functions and traits for spr, spr2, syr, syr2
@@ -1944,9 +1946,11 @@ pub unsafe fn hemm<T>(
 where
     T: HemmType,
 {
-    T::rocblas_hemm(
-        handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc,
-    )
+    unsafe {
+        T::rocblas_hemm(
+            handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc,
+        )
+    }
 }
 
 /// Hermitian rank-k update
@@ -1973,7 +1977,9 @@ pub unsafe fn herk<T, R>(
 where
     T: HerkType<ScalarType = R>,
 {
-    T::rocblas_herk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
+    unsafe {
+        T::rocblas_herk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
+    }
 }
 
 pub unsafe fn syr_batched<T>(
@@ -1990,7 +1996,9 @@ pub unsafe fn syr_batched<T>(
 where
     T: SyrBatchedType,
 {
-    T::rocblas_syr_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
+    unsafe {
+        T::rocblas_syr_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
+    }
 }
 
 /// Strided batched symmetric rank-1 update
@@ -2010,19 +2018,21 @@ pub unsafe fn syr_strided_batched<T>(
 where
     T: SyrStridedBatchedType,
 {
-    T::rocblas_syr_strided_batched(
-        handle,
-        uplo,
-        n,
-        alpha,
-        x,
-        incx,
-        stride_x,
-        A,
-        lda,
-        stride_A,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_syr_strided_batched(
+            handle,
+            uplo,
+            n,
+            alpha,
+            x,
+            incx,
+            stride_x,
+            A,
+            lda,
+            stride_A,
+            batch_count,
+        )
+    }
 }
 
 /// Batched symmetric rank-2 update

--- a/src/rocblas/level3.rs
+++ b/src/rocblas/level3.rs
@@ -57,9 +57,11 @@ pub unsafe fn gemm<T>(
 where
     T: GemmType,
 {
-    T::rocblas_gemm(
-        handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc,
-    )
+    unsafe {
+        T::rocblas_gemm(
+            handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc,
+        )
+    }
 }
 
 /// Batched matrix-matrix multiplication
@@ -106,23 +108,25 @@ pub unsafe fn gemm_batched<T>(
 where
     T: GemmBatchedType,
 {
-    T::rocblas_gemm_batched(
-        handle,
-        transa,
-        transb,
-        m,
-        n,
-        k,
-        alpha,
-        A,
-        lda,
-        B,
-        ldb,
-        beta,
-        C,
-        ldc,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_gemm_batched(
+            handle,
+            transa,
+            transb,
+            m,
+            n,
+            k,
+            alpha,
+            A,
+            lda,
+            B,
+            ldb,
+            beta,
+            C,
+            ldc,
+            batch_count,
+        )
+    }
 }
 
 /// Strided batched matrix-matrix multiplication
@@ -175,26 +179,28 @@ pub unsafe fn gemm_strided_batched<T>(
 where
     T: GemmStridedBatchedType,
 {
-    T::rocblas_gemm_strided_batched(
-        handle,
-        transa,
-        transb,
-        m,
-        n,
-        k,
-        alpha,
-        A,
-        lda,
-        stride_A,
-        B,
-        ldb,
-        stride_B,
-        beta,
-        C,
-        ldc,
-        stride_C,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_gemm_strided_batched(
+            handle,
+            transa,
+            transb,
+            m,
+            n,
+            k,
+            alpha,
+            A,
+            lda,
+            stride_A,
+            B,
+            ldb,
+            stride_B,
+            beta,
+            C,
+            ldc,
+            stride_C,
+            batch_count,
+        )
+    }
 }
 
 /// General matrix-matrix multiplication with extended precision
@@ -2016,22 +2022,24 @@ pub unsafe fn hemm_batched<T>(
 where
     T: HemmBatchedType,
 {
-    T::rocblas_hemm_batched(
-        handle,
-        side,
-        uplo,
-        m,
-        n,
-        alpha,
-        A,
-        lda,
-        B,
-        ldb,
-        beta,
-        C,
-        ldc,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_hemm_batched(
+            handle,
+            side,
+            uplo,
+            m,
+            n,
+            alpha,
+            A,
+            lda,
+            B,
+            ldb,
+            beta,
+            C,
+            ldc,
+            batch_count,
+        )
+    }
 }
 
 /// Strided batched Hermitian matrix-matrix multiplication
@@ -2057,25 +2065,27 @@ pub unsafe fn hemm_strided_batched<T>(
 where
     T: HemmStridedBatchedType,
 {
-    T::rocblas_hemm_strided_batched(
-        handle,
-        side,
-        uplo,
-        m,
-        n,
-        alpha,
-        A,
-        lda,
-        stride_A,
-        B,
-        ldb,
-        stride_B,
-        beta,
-        C,
-        ldc,
-        stride_C,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_hemm_strided_batched(
+            handle,
+            side,
+            uplo,
+            m,
+            n,
+            alpha,
+            A,
+            lda,
+            stride_A,
+            B,
+            ldb,
+            stride_B,
+            beta,
+            C,
+            ldc,
+            stride_C,
+            batch_count,
+        )
+    }
 }
 
 /// Batched Hermitian rank-k update
@@ -2096,20 +2106,22 @@ pub unsafe fn herk_batched<T, R>(
 where
     T: HerkBatchedType<ScalarType = R>,
 {
-    T::rocblas_herk_batched(
-        handle,
-        uplo,
-        transA,
-        n,
-        k,
-        alpha,
-        A,
-        lda,
-        beta,
-        C,
-        ldc,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_herk_batched(
+            handle,
+            uplo,
+            transA,
+            n,
+            k,
+            alpha,
+            A,
+            lda,
+            beta,
+            C,
+            ldc,
+            batch_count,
+        )
+    }
 }
 
 /// Strided batched Hermitian rank-k update
@@ -2132,22 +2144,24 @@ pub unsafe fn herk_strided_batched<T, R>(
 where
     T: HerkStridedBatchedType<ScalarType = R>,
 {
-    T::rocblas_herk_strided_batched(
-        handle,
-        uplo,
-        transA,
-        n,
-        k,
-        alpha,
-        A,
-        lda,
-        stride_A,
-        beta,
-        C,
-        ldc,
-        stride_C,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_herk_strided_batched(
+            handle,
+            uplo,
+            transA,
+            n,
+            k,
+            alpha,
+            A,
+            lda,
+            stride_A,
+            beta,
+            C,
+            ldc,
+            stride_C,
+            batch_count,
+        )
+    }
 }
 
 /// Hermitian rank-k update with two matrices
@@ -2190,9 +2204,11 @@ pub unsafe fn herkx<T, R>(
 where
     T: HerkxType<ScalarType = R>,
 {
-    T::rocblas_herkx(
-        handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc,
-    )
+    unsafe {
+        T::rocblas_herkx(
+            handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc,
+        )
+    }
 }
 
 /// Batched Hermitian rank-k update with two matrices
@@ -2215,22 +2231,24 @@ pub unsafe fn herkx_batched<T, R>(
 where
     T: HerkxBatchedType<ScalarType = R>,
 {
-    T::rocblas_herkx_batched(
-        handle,
-        uplo,
-        trans,
-        n,
-        k,
-        alpha,
-        A,
-        lda,
-        B,
-        ldb,
-        beta,
-        C,
-        ldc,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_herkx_batched(
+            handle,
+            uplo,
+            trans,
+            n,
+            k,
+            alpha,
+            A,
+            lda,
+            B,
+            ldb,
+            beta,
+            C,
+            ldc,
+            batch_count,
+        )
+    }
 }
 
 /// Strided batched Hermitian rank-k update with two matrices
@@ -2256,25 +2274,27 @@ pub unsafe fn herkx_strided_batched<T, R>(
 where
     T: HerkxStridedBatchedType<ScalarType = R>,
 {
-    T::rocblas_herkx_strided_batched(
-        handle,
-        uplo,
-        trans,
-        n,
-        k,
-        alpha,
-        A,
-        lda,
-        stride_A,
-        B,
-        ldb,
-        stride_B,
-        beta,
-        C,
-        ldc,
-        stride_C,
-        batch_count,
-    )
+    unsafe {
+        T::rocblas_herkx_strided_batched(
+            handle,
+            uplo,
+            trans,
+            n,
+            k,
+            alpha,
+            A,
+            lda,
+            stride_A,
+            B,
+            ldb,
+            stride_B,
+            beta,
+            C,
+            ldc,
+            stride_C,
+            batch_count,
+        )
+    }
 }
 
 /// Trait for types that can be used with herkx


### PR DESCRIPTION
Edition 2024 promotes `unsafe_op_in_unsafe_fn` to deny-by-default. The rocblas `level1`/`level2`/`level3` forwarders are `unsafe fn`s that call the raw FFI without an explicit `unsafe { }` block, which is a hard `E0133` under edition 2024 (and is already enforced on the native Windows/MSVC build).

This wraps each forwarder body in an explicit `unsafe { }` block. No behavior change on any platform; purely an edition-2024 compliance fix. Identical codegen.

Built with `cargo +nightly build --release` on gfx1151 / ROCm 7.13.