### PR TITLE
refactor: use bindgen FFI status/enum types instead of hardcoded u32

### DIFF
--- a/src/rocarray/random.rs
+++ b/src/rocarray/random.rs
@@ -414,7 +414,10 @@ pub struct RandomUtils;
 
 impl RandomUtils {
     /// Create a seeded generator for reproducible results
-    pub fn seeded_generator(seed: u64, rng_type: u32) -> Result<PseudoRng> {
+    pub fn seeded_generator(
+        seed: u64,
+        rng_type: crate::rocrand::bindings::rocrand_rng_type,
+    ) -> Result<PseudoRng> {
         let mut generator = PseudoRng::new(rng_type)?;
         generator.set_seed(seed)?;
         generator.initialize()?;

--- a/src/rocblas/macros.rs
+++ b/src/rocblas/macros.rs
@@ -32,7 +32,7 @@ macro_rules! impl_rocblas_traits {
         ($($fn_arg:ty),+ $(,)?),
         ($($call_arg:expr),+ $(,)?)
     ) => {
-        type $fn_type<T> = unsafe extern "C" fn($($fn_arg),+) -> u32;
+        type $fn_type<T> = unsafe extern "C" fn($($fn_arg),+) -> ffi::rocblas_status;
 
         pub trait $trait_name {
             fn func() -> $fn_type<Self>;

--- a/src/rocfft/description.rs
+++ b/src/rocfft/description.rs
@@ -21,7 +21,7 @@ pub enum CommType {
     MPI,
 }
 
-impl From<CommType> for u32 {
+impl From<CommType> for bindings::rocfft_comm_type {
     fn from(comm_type: CommType) -> Self {
         match comm_type {
             CommType::None => bindings::rocfft_comm_type_e_rocfft_comm_none,

--- a/src/rocfft/error.rs
+++ b/src/rocfft/error.rs
@@ -75,8 +75,8 @@ impl From<NulError> for Error {
     }
 }
 
-impl From<u32> for Error {
-    fn from(status: u32) -> Self {
+impl From<bindings::rocfft_status_e> for Error {
+    fn from(status: bindings::rocfft_status_e) -> Self {
         match status {
             bindings::rocfft_status_e_rocfft_status_success => {
                 panic!("Tried to convert successful status to error")
@@ -89,7 +89,7 @@ impl From<u32> for Error {
             bindings::rocfft_status_e_rocfft_status_invalid_distance => Error::InvalidDistance,
             bindings::rocfft_status_e_rocfft_status_invalid_offset => Error::InvalidOffset,
             bindings::rocfft_status_e_rocfft_status_invalid_work_buffer => Error::InvalidWorkBuffer,
-            code => Error::Unknown(code),
+            code => Error::Unknown(code as u32),
         }
     }
 }
@@ -115,7 +115,7 @@ impl From<&'static str> for Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Check a rocFFT status code and convert to a Rust Result
-pub(crate) fn check_error(status: u32) -> Result<()> {
+pub(crate) fn check_error(status: bindings::rocfft_status_e) -> Result<()> {
     match status {
         bindings::rocfft_status_e_rocfft_status_success => Ok(()),
         _ => Err(Error::from(status)),
@@ -155,9 +155,9 @@ pub(crate) fn check_dimensions(dimensions: usize) -> Result<()> {
 /// Helper function to detect incompatible array types for a transform
 #[inline]
 pub(crate) fn check_compatible_types(
-    transform_type: u32,
-    in_array_type: u32,
-    out_array_type: u32,
+    transform_type: bindings::rocfft_transform_type,
+    in_array_type: bindings::rocfft_array_type,
+    out_array_type: bindings::rocfft_array_type,
 ) -> Result<()> {
     match transform_type {
         bindings::rocfft_transform_type_e_rocfft_transform_type_complex_forward

--- a/src/rocfft/plan.rs
+++ b/src/rocfft/plan.rs
@@ -24,7 +24,7 @@ pub enum TransformType {
     RealInverse,
 }
 
-impl From<TransformType> for u32 {
+impl From<TransformType> for bindings::rocfft_transform_type {
     fn from(transform_type: TransformType) -> Self {
         match transform_type {
             TransformType::ComplexForward => {
@@ -54,7 +54,7 @@ pub enum Precision {
     Half,
 }
 
-impl From<Precision> for u32 {
+impl From<Precision> for bindings::rocfft_precision {
     fn from(precision: Precision) -> Self {
         match precision {
             Precision::Single => bindings::rocfft_precision_e_rocfft_precision_single,
@@ -73,7 +73,7 @@ pub enum PlacementType {
     NotInPlace,
 }
 
-impl From<PlacementType> for u32 {
+impl From<PlacementType> for bindings::rocfft_result_placement {
     fn from(placement: PlacementType) -> Self {
         match placement {
             PlacementType::InPlace => bindings::rocfft_result_placement_e_rocfft_placement_inplace,
@@ -101,7 +101,7 @@ pub enum ArrayType {
     Unset,
 }
 
-impl From<ArrayType> for u32 {
+impl From<ArrayType> for bindings::rocfft_array_type {
     fn from(array_type: ArrayType) -> Self {
         match array_type {
             ArrayType::ComplexInterleaved => {

--- a/src/rocrand/error.rs
+++ b/src/rocrand/error.rs
@@ -34,7 +34,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
     /// Convert a rocrand status code to a Result
-    pub(crate) fn from_status(status: u32) -> Result<()> {
+    pub(crate) fn from_status(status: bindings::rocrand_status) -> Result<()> {
         match status {
             bindings::rocrand_status_ROCRAND_STATUS_SUCCESS => Ok(()),
             bindings::rocrand_status_ROCRAND_STATUS_VERSION_MISMATCH => Err(Error::VersionMismatch),
@@ -52,7 +52,7 @@ impl Error {
             }
             bindings::rocrand_status_ROCRAND_STATUS_LAUNCH_FAILURE => Err(Error::LaunchFailure),
             bindings::rocrand_status_ROCRAND_STATUS_INTERNAL_ERROR => Err(Error::InternalError),
-            other => Err(Error::Unknown(other)),
+            other => Err(Error::Unknown(other as u32)),
         }
     }
 }

--- a/src/rocrand/generator.rs
+++ b/src/rocrand/generator.rs
@@ -19,7 +19,7 @@ pub trait Generator {
     }
 
     /// Set the ordering of the generator
-    fn set_ordering(&mut self, ordering: u32) -> Result<()> {
+    fn set_ordering(&mut self, ordering: bindings::rocrand_ordering) -> Result<()> {
         unsafe { Error::from_status(bindings::rocrand_set_ordering(self.as_ptr(), ordering)) }
     }
 
@@ -56,7 +56,7 @@ impl PseudoRng {
     ///
     /// let generator = PseudoRng::new(rng_type::XORWOW).unwrap();
     /// ```
-    pub fn new(rng_type: u32) -> Result<Self> {
+    pub fn new(rng_type: bindings::rocrand_rng_type) -> Result<Self> {
         let mut generator = ptr::null_mut();
         unsafe {
             Error::from_status(bindings::rocrand_create_generator(&mut generator, rng_type))?;
@@ -67,7 +67,7 @@ impl PseudoRng {
     }
 
     /// Create a new host-side pseudorandom number generator of the specified type.
-    pub fn new_host(rng_type: u32) -> Result<Self> {
+    pub fn new_host(rng_type: bindings::rocrand_rng_type) -> Result<Self> {
         let mut generator = ptr::null_mut();
         unsafe {
             Error::from_status(bindings::rocrand_create_generator_host(
@@ -315,7 +315,7 @@ pub struct QuasiRng {
 
 impl QuasiRng {
     /// Create a new quasirandom number generator of the specified type.
-    pub fn new(rng_type: u32) -> Result<Self> {
+    pub fn new(rng_type: bindings::rocrand_rng_type) -> Result<Self> {
         let mut generator = ptr::null_mut();
         unsafe {
             Error::from_status(bindings::rocrand_create_generator(&mut generator, rng_type))?;

--- a/src/rocrand/mod.rs
+++ b/src/rocrand/mod.rs
@@ -19,53 +19,66 @@ pub use generator::{Generator, PseudoRng, QuasiRng};
 
 /// Convenient re-exports of random number generator types
 pub mod rng_type {
-    use super::bindings;
+    use super::bindings::{self, rocrand_rng_type};
 
-    pub const PSEUDO_DEFAULT: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_DEFAULT;
-    pub const XORWOW: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_XORWOW;
-    pub const MRG32K3A: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MRG32K3A;
-    pub const MTGP32: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MTGP32;
-    pub const PHILOX4_32_10: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_PHILOX4_32_10;
-    pub const MRG31K3P: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MRG31K3P;
-    pub const LFSR113: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_LFSR113;
-    pub const MT19937: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MT19937;
-    pub const THREEFRY2_32_20: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY2_32_20;
-    pub const THREEFRY2_64_20: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY2_64_20;
-    pub const THREEFRY4_32_20: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY4_32_20;
-    pub const THREEFRY4_64_20: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY4_64_20;
+    pub const PSEUDO_DEFAULT: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_DEFAULT;
+    pub const XORWOW: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_XORWOW;
+    pub const MRG32K3A: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MRG32K3A;
+    pub const MTGP32: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MTGP32;
+    pub const PHILOX4_32_10: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_PHILOX4_32_10;
+    pub const MRG31K3P: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MRG31K3P;
+    pub const LFSR113: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_LFSR113;
+    pub const MT19937: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_MT19937;
+    pub const THREEFRY2_32_20: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY2_32_20;
+    pub const THREEFRY2_64_20: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY2_64_20;
+    pub const THREEFRY4_32_20: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY4_32_20;
+    pub const THREEFRY4_64_20: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_PSEUDO_THREEFRY4_64_20;
 
-    pub const QUASI_DEFAULT: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_DEFAULT;
-    pub const SOBOL32: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_SOBOL32;
-    pub const SCRAMBLED_SOBOL32: u32 =
+    pub const QUASI_DEFAULT: rocrand_rng_type =
+        bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_DEFAULT;
+    pub const SOBOL32: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_SOBOL32;
+    pub const SCRAMBLED_SOBOL32: rocrand_rng_type =
         bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32;
-    pub const SOBOL64: u32 = bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_SOBOL64;
-    pub const SCRAMBLED_SOBOL64: u32 =
+    pub const SOBOL64: rocrand_rng_type = bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_SOBOL64;
+    pub const SCRAMBLED_SOBOL64: rocrand_rng_type =
         bindings::rocrand_rng_type_ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64;
 }
 
 /// Convenient re-exports of ordering constants
 pub mod ordering {
-    use super::bindings;
+    use super::bindings::{self, rocrand_ordering};
 
-    pub const PSEUDO_BEST: u32 = bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_BEST;
-    pub const PSEUDO_DEFAULT: u32 = bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_DEFAULT;
-    pub const PSEUDO_SEEDED: u32 = bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_SEEDED;
-    pub const PSEUDO_LEGACY: u32 = bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_LEGACY;
-    pub const PSEUDO_DYNAMIC: u32 = bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_DYNAMIC;
-    pub const QUASI_DEFAULT: u32 = bindings::rocrand_ordering_ROCRAND_ORDERING_QUASI_DEFAULT;
+    pub const PSEUDO_BEST: rocrand_ordering =
+        bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_BEST;
+    pub const PSEUDO_DEFAULT: rocrand_ordering =
+        bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_DEFAULT;
+    pub const PSEUDO_SEEDED: rocrand_ordering =
+        bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_SEEDED;
+    pub const PSEUDO_LEGACY: rocrand_ordering =
+        bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_LEGACY;
+    pub const PSEUDO_DYNAMIC: rocrand_ordering =
+        bindings::rocrand_ordering_ROCRAND_ORDERING_PSEUDO_DYNAMIC;
+    pub const QUASI_DEFAULT: rocrand_ordering =
+        bindings::rocrand_ordering_ROCRAND_ORDERING_QUASI_DEFAULT;
 }
 
 /// Re-export direction vector constants
 pub mod direction_vector_set {
-    use super::bindings;
+    use super::bindings::{self, rocrand_direction_vector_set};
 
-    pub const VECTORS_32_JOEKUO6: u32 =
+    pub const VECTORS_32_JOEKUO6: rocrand_direction_vector_set =
         bindings::rocrand_direction_vector_set_ROCRAND_DIRECTION_VECTORS_32_JOEKUO6;
-    pub const SCRAMBLED_VECTORS_32_JOEKUO6: u32 =
+    pub const SCRAMBLED_VECTORS_32_JOEKUO6: rocrand_direction_vector_set =
         bindings::rocrand_direction_vector_set_ROCRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6;
-    pub const VECTORS_64_JOEKUO6: u32 =
+    pub const VECTORS_64_JOEKUO6: rocrand_direction_vector_set =
         bindings::rocrand_direction_vector_set_ROCRAND_DIRECTION_VECTORS_64_JOEKUO6;
-    pub const SCRAMBLED_VECTORS_64_JOEKUO6: u32 =
+    pub const SCRAMBLED_VECTORS_64_JOEKUO6: rocrand_direction_vector_set =
         bindings::rocrand_direction_vector_set_ROCRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6;
 }
 


### PR DESCRIPTION
Several FFI return/param sites used a literal `u32` where bindgen already emits a typed alias (`rocblas_status`, `rocrand_rng_type`, `rocfft_status`, ...). On Linux the alias is `u32`, so this is a no-op; on the native Windows/MSVC ABI the same alias is `i32`, so the literal `u32` is the wrong type and only the alias is correct.

This switches those sites to the bindgen-generated aliases. Public `Error` types stay byte-identical via an explicit `as u32` where the value crosses an API boundary. **No bindings are regenerated** — the aliases referenced already exist on `master`.

Built with `cargo +nightly build --release` on gfx1151 / ROCm 7.13.